### PR TITLE
chore(release): publish v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.8.2](https://github.com/hidoo/handlebars-lib/compare/v0.8.1...v0.8.2) (2021-06-08)
+# [1.0.0](https://github.com/hidoo/handlebars-lib/compare/v0.8.2...v1.0.0) (2024-03-18)
 
+### Bug Fixes
+
+* **deps:** update dependency glob to v7.2.0 ([769c473](https://github.com/hidoo/handlebars-lib/commit/769c4739c8ecf99b7a056f747b9a2ecff7a189f0))
+* **deps:** update dependency glob to v7.2.3 ([0a0d680](https://github.com/hidoo/handlebars-lib/commit/0a0d6809160909ce4e7d70c8892dd010a2958774))
+* **deps:** update dependency glob-parent to v6.0.1 ([881af65](https://github.com/hidoo/handlebars-lib/commit/881af6564acdf41703bb633c9f69eaafd62312d4))
+* **deps:** update dependency glob-parent to v6.0.2 ([0fc5225](https://github.com/hidoo/handlebars-lib/commit/0fc52254707c16efd98b537134a7c9563838d47c))
+* **deps:** update dependency highlight.js to v11.1.0 ([dc5539f](https://github.com/hidoo/handlebars-lib/commit/dc5539f3fd903fea75776d7c296c1fcba6b71ec4))
+* **deps:** update dependency highlight.js to v11.3.1 ([eb7ce58](https://github.com/hidoo/handlebars-lib/commit/eb7ce583e918640c270714f63693a2045a51f33e))
+* **deps:** update dependency marked to v2.1.2 ([ff01136](https://github.com/hidoo/handlebars-lib/commit/ff01136f71589cb71efb5b8bcb61f22acb3b73ba))
+* **deps:** update dependency marked to v2.1.3 ([9de06ec](https://github.com/hidoo/handlebars-lib/commit/9de06ecb45e5daeddbcf0709235807fd50334267))
+
+* fix!: migrate to es modules ([e6fa7e5](https://github.com/hidoo/handlebars-lib/commit/e6fa7e511d6bf0a98e60f6ee2baf8cd9e774eb29))
+* fix!: update supported nodejs versions ([dc2cc7a](https://github.com/hidoo/handlebars-lib/commit/dc2cc7afaf680d6480822c00e93a340a1b912598))
+
+### BREAKING CHANGES
+
+* Requires ES Modules.
+* Drop Node.js 12, 14, 16 support
+
+## [0.8.2](https://github.com/hidoo/handlebars-lib/compare/v0.8.1...v0.8.2) (2021-06-08)
 
 ### Bug Fixes
 
@@ -22,12 +42,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **helpers:** fix deprecated warnings ([ce4daf1](https://github.com/hidoo/handlebars-lib/commit/ce4daf173aaa28a44484f30586ff8557f50a52c2))
 * **node:** remove node v10 support ([c75e7cb](https://github.com/hidoo/handlebars-lib/commit/c75e7cb56f5eaba844f51f2680835c99b23ead8c))
 
-
-
-
-
 ## [0.8.1](https://github.com/hidoo/handlebars-lib/compare/v0.8.0...v0.8.1) (2021-03-29)
-
 
 ### Bug Fixes
 
@@ -44,12 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **express-engine:** fix test case when default helpers use ([d1ebe8c](https://github.com/hidoo/handlebars-lib/commit/d1ebe8c3b1a1bb07dabcab471ff0e9dcd2606a8b))
 * **helpers:** fix test case of highlight and markdown helpers ([d1cce0a](https://github.com/hidoo/handlebars-lib/commit/d1cce0a3fee5930153c712db77a2c579f1de7eff))
 
-
-
-
-
 # [0.8.0](https://github.com/hidoo/handlebars-lib/compare/v0.7.0...v0.8.0) (2020-05-07)
-
 
 ### Bug Fixes
 
@@ -61,19 +71,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency marked to v1 ([82ea71a](https://github.com/hidoo/handlebars-lib/commit/82ea71a27e3e26b600cdeae28035ec46175e4075))
 * **deps:** update dependency path-browserify to v1.0.1 ([2c1e912](https://github.com/hidoo/handlebars-lib/commit/2c1e9125bbd3d3e439841dc8b8246226864c48b4))
 
-
 ### Features
 
 * **helpers:** add often used helpers ([24f9e45](https://github.com/hidoo/handlebars-lib/commit/24f9e45fb77f31427f6e43cb99462bd1aedbf608))
 * **helpers:** add register api ([c74f085](https://github.com/hidoo/handlebars-lib/commit/c74f085f26b60629e04a7de543d374db72e63d58))
 * **node:** add node v14 support ([1a16899](https://github.com/hidoo/handlebars-lib/commit/1a16899bc02ba7d1655aa39a5506cb3ac611ca6b))
 
-
-
-
-
 # [0.7.0](https://github.com/hidoo/handlebars-lib/compare/v0.6.1...v0.7.0) (2020-03-03)
-
 
 ### Bug Fixes
 
@@ -83,12 +87,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency marked to v0.8.0 ([350d119](https://github.com/hidoo/handlebars-lib/commit/350d11941987d4290d7588344f92ca850ccd3e04))
 * **node:** remove node v8 support ([3d52fde](https://github.com/hidoo/handlebars-lib/commit/3d52fde59fad4484146fe923597bd2106c89f4cd))
 
-
-
-
-
 ## [0.6.1](https://github.com/hidoo/handlebars-lib/compare/v0.6.0...v0.6.1) (2019-11-11)
-
 
 ### Bug Fixes
 
@@ -99,12 +98,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency highlight.js to v9.15.9 ([0fc9b8d](https://github.com/hidoo/handlebars-lib/commit/0fc9b8d))
 * **deps:** update dependency highlight.js to v9.16.2 ([3a3b0f3](https://github.com/hidoo/handlebars-lib/commit/3a3b0f3))
 
-
-
-
-
 # 0.6.0 (2019-08-05)
-
 
 ### Bug Fixes
 
@@ -113,7 +107,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **markdown:** fix to use hljs.highlight from hljs.highlightAuto ([a32033d](https://github.com/hidoo/handlebars-lib/commit/a32033d))
 * **package:** update @hidoo/handlebars-helpers to version 0.4.1 ([e165915](https://github.com/hidoo/handlebars-lib/commit/e165915))
 * **sliceArray:** fix to export sliceArray ([37c95db](https://github.com/hidoo/handlebars-lib/commit/37c95db))
-
 
 ### Features
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/lerna-lite/lerna-lite/main/packages/cli/schemas/lerna-schema.json",
   "npmClient": "pnpm",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "command": {
     "version": {
       "conventionalCommits": true,
@@ -10,9 +10,15 @@
       "private": false
     },
     "publish": {
-      "removePackageFields": ["devDependencies", "scripts"]
+      "removePackageFields": [
+        "devDependencies",
+        "scripts"
+      ]
     }
   },
-  "ignoreChanges": ["**/test/**", "**/CHANGELOG.md"],
+  "ignoreChanges": [
+    "**/test/**",
+    "**/CHANGELOG.md"
+  ],
   "includeMergedTags": true
 }

--- a/package.json
+++ b/package.json
@@ -35,12 +35,5 @@
     "eslint": "8.57.0",
     "lint-staged": "15.2.2",
     "prettier": "3.2.5"
-  },
-  "pnpm": {
-    "overrides": {
-      "glob-parent": "^6.0.0",
-      "minimist": "^1.2.5",
-      "trim-newlines": "^4.0.0"
-    }
   }
 }

--- a/packages/express-engine-handlebars/CHANGELOG.md
+++ b/packages/express-engine-handlebars/CHANGELOG.md
@@ -3,8 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.8.2](https://github.com/hidoo/handlebars-lib/compare/v0.8.1...v0.8.2) (2021-06-08)
+# [1.0.0](https://github.com/hidoo/handlebars-lib/compare/v0.8.2...v1.0.0) (2024-03-18)
 
+**Note:** Version bump only for package @hidoo/express-engine-handlebars
+
+## [0.8.2](https://github.com/hidoo/handlebars-lib/compare/v0.8.1...v0.8.2) (2021-06-08)
 
 ### Bug Fixes
 
@@ -13,12 +16,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency glob-parent to v6 ([d44ab65](https://github.com/hidoo/handlebars-lib/commit/d44ab65793e21bab236f5035ab21860f4b7f9e43))
 * **node:** remove node v10 support ([c75e7cb](https://github.com/hidoo/handlebars-lib/commit/c75e7cb56f5eaba844f51f2680835c99b23ead8c))
 
-
-
-
-
 ## [0.8.1](https://github.com/hidoo/handlebars-lib/compare/v0.8.0...v0.8.1) (2021-03-29)
-
 
 ### Bug Fixes
 
@@ -26,34 +24,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency vinyl to v2.2.1 ([f9e9687](https://github.com/hidoo/handlebars-lib/commit/f9e9687435bcb4b9b5c868f130fcdf8852082295))
 * **express-engine:** fix test case when default helpers use ([d1ebe8c](https://github.com/hidoo/handlebars-lib/commit/d1ebe8c3b1a1bb07dabcab471ff0e9dcd2606a8b))
 
-
-
-
-
 # [0.8.0](https://github.com/hidoo/handlebars-lib/compare/v0.7.0...v0.8.0) (2020-05-07)
-
 
 ### Bug Fixes
 
 * **deps:** update dependency glob-parent to v5.1.1 ([0aac858](https://github.com/hidoo/handlebars-lib/commit/0aac858558bbee72acee5c3c1041baf70bb10896))
 
-
-
-
-
 # [0.7.0](https://github.com/hidoo/handlebars-lib/compare/v0.6.1...v0.7.0) (2020-03-03)
-
 
 ### Bug Fixes
 
 * **node:** remove node v8 support ([3d52fde](https://github.com/hidoo/handlebars-lib/commit/3d52fde59fad4484146fe923597bd2106c89f4cd))
 
-
-
-
-
 ## [0.6.1](https://github.com/hidoo/handlebars-lib/compare/v0.6.0...v0.6.1) (2019-11-11)
-
 
 ### Bug Fixes
 
@@ -61,104 +44,69 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency glob to v7.1.6 ([b0d5c69](https://github.com/hidoo/handlebars-lib/commit/b0d5c69))
 * **deps:** update dependency glob-parent to v5.1.0 ([b8ff4ba](https://github.com/hidoo/handlebars-lib/commit/b8ff4ba))
 
-
-
-
-
 # 0.6.0 (2019-08-05)
-
 
 ### Bug Fixes
 
 * **package:** update @hidoo/handlebars-helpers to version 0.4.1 ([e165915](https://github.com/hidoo/handlebars-lib/commit/e165915))
 
-
 ### Features
 
 * **packages:** add handlebars template engine for express ([3d1f1c9](https://github.com/hidoo/handlebars-lib/commit/3d1f1c9))
 
-
-
-
-
 <a name="0.1.9"></a>
 ## [0.1.9](https://github.com/hidoo/express-engine-handlebars/compare/v0.1.8...v0.1.9) (2019-06-10)
-
 
 ### Bug Fixes
 
 * **package:** update glob-parent to version 4.0.0 ([641cb22](https://github.com/hidoo/express-engine-handlebars/commit/641cb22))
 
-
-
 <a name="0.1.8"></a>
 ## [0.1.8](https://github.com/hidoo/express-engine-handlebars/compare/v0.1.7...v0.1.8) (2019-03-11)
-
 
 ### Bug Fixes
 
 * **package:** update [@hidoo](https://github.com/hidoo)/handlebars-helpers to version 0.5.0 ([c171cdc](https://github.com/hidoo/express-engine-handlebars/commit/c171cdc))
 
-
-
 <a name="0.1.7"></a>
 ## [0.1.7](https://github.com/hidoo/express-engine-handlebars/compare/v0.1.6...v0.1.7) (2019-03-04)
 
-
-
 <a name="0.1.6"></a>
 ## [0.1.6](https://github.com/hidoo/express-engine-handlebars/compare/v0.1.5...v0.1.6) (2018-10-26)
-
 
 ### Bug Fixes
 
 * **package:** update [@hidoo](https://github.com/hidoo)/handlebars-helpers to version 0.4.1 ([c4b0b8f](https://github.com/hidoo/express-engine-handlebars/commit/c4b0b8f))
 
-
-
 <a name="0.1.5"></a>
 ## [0.1.5](https://github.com/hidoo/express-engine-handlebars/compare/v0.1.4...v0.1.5) (2018-10-25)
-
 
 ### Bug Fixes
 
 * **package:** update [@hidoo](https://github.com/hidoo)/handlebars-helpers to version 0.4.0 ([ee0b6a4](https://github.com/hidoo/express-engine-handlebars/commit/ee0b6a4))
 
-
-
 <a name="0.1.4"></a>
 ## [0.1.4](https://github.com/hidoo/express-engine-handlebars/compare/v0.1.3...v0.1.4) (2018-10-16)
-
 
 ### Bug Fixes
 
 * **package:** update [@hidoo](https://github.com/hidoo)/handlebars-helpers to version 0.3.0 ([a839474](https://github.com/hidoo/express-engine-handlebars/commit/a839474))
 
-
-
 <a name="0.1.3"></a>
 ## [0.1.3](https://github.com/hidoo/express-engine-handlebars/compare/v0.1.2...v0.1.3) (2018-10-15)
-
-
 
 <a name="0.1.2"></a>
 ## [0.1.2](https://github.com/hidoo/express-engine-handlebars/compare/v0.1.1...v0.1.2) (2018-10-15)
 
-
-
 <a name="0.1.1"></a>
 ## [0.1.1](https://github.com/hidoo/express-engine-handlebars/compare/v0.1.0...v0.1.1) (2018-10-04)
-
 
 ### Bug Fixes
 
 * **package:** update [@hidoo](https://github.com/hidoo)/handlebars-helpers to version 0.2.0 ([2b94319](https://github.com/hidoo/express-engine-handlebars/commit/2b94319))
 
-
-
 <a name="0.1.0"></a>
 # [0.1.0](https://github.com/hidoo/express-engine-handlebars/compare/d219722...v0.1.0) (2018-09-20)
-
 
 ### Features
 

--- a/packages/express-engine-handlebars/package.json
+++ b/packages/express-engine-handlebars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hidoo/express-engine-handlebars",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "description": "Handlebars template engine for express.",
   "engines": {
     "node": ">=18.0.0"

--- a/packages/handlebars-helpers/CHANGELOG.md
+++ b/packages/handlebars-helpers/CHANGELOG.md
@@ -3,8 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.8.2](https://github.com/hidoo/handlebars-lib/compare/v0.8.1...v0.8.2) (2021-06-08)
+# [1.0.0](https://github.com/hidoo/handlebars-lib/compare/v0.8.2...v1.0.0) (2024-03-18)
 
+**Note:** Version bump only for package @hidoo/handlebars-helpers
+
+## [0.8.2](https://github.com/hidoo/handlebars-lib/compare/v0.8.1...v0.8.2) (2021-06-08)
 
 ### Bug Fixes
 
@@ -20,12 +23,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **helpers:** fix deprecated warnings ([ce4daf1](https://github.com/hidoo/handlebars-lib/commit/ce4daf173aaa28a44484f30586ff8557f50a52c2))
 * **node:** remove node v10 support ([c75e7cb](https://github.com/hidoo/handlebars-lib/commit/c75e7cb56f5eaba844f51f2680835c99b23ead8c))
 
-
-
-
-
 ## [0.8.1](https://github.com/hidoo/handlebars-lib/compare/v0.8.0...v0.8.1) (2021-03-29)
-
 
 ### Bug Fixes
 
@@ -39,12 +37,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency marked to v2.0.1 ([9205321](https://github.com/hidoo/handlebars-lib/commit/92053218b2672c684dadbd5b01dd2aa31d0666d8))
 * **helpers:** fix test case of highlight and markdown helpers ([d1cce0a](https://github.com/hidoo/handlebars-lib/commit/d1cce0a3fee5930153c712db77a2c579f1de7eff))
 
-
-
-
-
 # [0.8.0](https://github.com/hidoo/handlebars-lib/compare/v0.7.0...v0.8.0) (2020-05-07)
-
 
 ### Bug Fixes
 
@@ -54,18 +47,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency marked to v1 ([82ea71a](https://github.com/hidoo/handlebars-lib/commit/82ea71a27e3e26b600cdeae28035ec46175e4075))
 * **deps:** update dependency path-browserify to v1.0.1 ([2c1e912](https://github.com/hidoo/handlebars-lib/commit/2c1e9125bbd3d3e439841dc8b8246226864c48b4))
 
-
 ### Features
 
 * **helpers:** add often used helpers ([24f9e45](https://github.com/hidoo/handlebars-lib/commit/24f9e45fb77f31427f6e43cb99462bd1aedbf608))
 * **helpers:** add register api ([c74f085](https://github.com/hidoo/handlebars-lib/commit/c74f085f26b60629e04a7de543d374db72e63d58))
 
-
-
-
-
 # [0.7.0](https://github.com/hidoo/handlebars-lib/compare/v0.6.1...v0.7.0) (2020-03-03)
-
 
 ### Bug Fixes
 
@@ -75,12 +62,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency marked to v0.8.0 ([350d119](https://github.com/hidoo/handlebars-lib/commit/350d11941987d4290d7588344f92ca850ccd3e04))
 * **node:** remove node v8 support ([3d52fde](https://github.com/hidoo/handlebars-lib/commit/3d52fde59fad4484146fe923597bd2106c89f4cd))
 
-
-
-
-
 ## [0.6.1](https://github.com/hidoo/handlebars-lib/compare/v0.6.0...v0.6.1) (2019-11-11)
-
 
 ### Bug Fixes
 
@@ -88,12 +70,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **deps:** update dependency highlight.js to v9.15.9 ([0fc9b8d](https://github.com/hidoo/handlebars-lib/commit/0fc9b8d))
 * **deps:** update dependency highlight.js to v9.16.2 ([3a3b0f3](https://github.com/hidoo/handlebars-lib/commit/3a3b0f3))
 
-
-
-
-
 # 0.6.0 (2019-08-05)
-
 
 ### Bug Fixes
 
@@ -102,111 +79,77 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **markdown:** fix to use hljs.highlight from hljs.highlightAuto ([a32033d](https://github.com/hidoo/handlebars-lib/commit/a32033d))
 * **sliceArray:** fix to export sliceArray ([37c95db](https://github.com/hidoo/handlebars-lib/commit/37c95db))
 
-
 ### Features
 
 * **markdown:** extend marked.Renderer to add "hljs" class to code block ([271182d](https://github.com/hidoo/handlebars-lib/commit/271182d))
 
-
-
-
-
 <a name="0.5.1"></a>
 ## [0.5.1](https://github.com/hidoo/handlebars-helpers/compare/v0.5.0...v0.5.1) (2019-06-10)
 
-
-
 <a name="0.5.0"></a>
 # [0.5.0](https://github.com/hidoo/handlebars-helpers/compare/v0.4.2...v0.5.0) (2019-03-11)
-
 
 ### Bug Fixes
 
 * **iflte:** fix to support falsy value ([f908472](https://github.com/hidoo/handlebars-helpers/commit/f908472))
 
-
 ### Features
 
 * add helper that return default value if value is falsy ([73649cb](https://github.com/hidoo/handlebars-helpers/commit/73649cb))
 
-
-
 <a name="0.4.2"></a>
 ## [0.4.2](https://github.com/hidoo/handlebars-helpers/compare/v0.4.1...v0.4.2) (2019-03-04)
-
 
 ### Bug Fixes
 
 * **package:** update marked to version 0.6.0 ([b4706f3](https://github.com/hidoo/handlebars-helpers/commit/b4706f3))
 
-
-
 <a name="0.4.1"></a>
 ## [0.4.1](https://github.com/hidoo/handlebars-helpers/compare/v0.4.0...v0.4.1) (2018-10-26)
-
 
 ### Bug Fixes
 
 * **sliceArray:** fix to export sliceArray ([4524c0f](https://github.com/hidoo/handlebars-helpers/commit/4524c0f))
 
-
-
 <a name="0.4.0"></a>
 # [0.4.0](https://github.com/hidoo/handlebars-helpers/compare/v0.3.0...v0.4.0) (2018-10-25)
-
 
 ### Features
 
 * **sliceArray:** add helper that wrapped array.prototype.slice ([47c3334](https://github.com/hidoo/handlebars-helpers/commit/47c3334))
 
-
-
 <a name="0.3.0"></a>
 # [0.3.0](https://github.com/hidoo/handlebars-helpers/compare/v0.2.2...v0.3.0) (2018-10-16)
-
 
 ### Features
 
 * **markdown:** extend marked.Renderer to add "hljs" class to code block ([78b5d6d](https://github.com/hidoo/handlebars-helpers/commit/78b5d6d))
 
-
-
 <a name="0.2.2"></a>
 ## [0.2.2](https://github.com/hidoo/handlebars-helpers/compare/v0.2.1...v0.2.2) (2018-10-15)
-
 
 ### Bug Fixes
 
 * **highlight:** fix to export hightlight ([ee22d75](https://github.com/hidoo/handlebars-helpers/commit/ee22d75))
 
-
-
 <a name="0.2.1"></a>
 ## [0.2.1](https://github.com/hidoo/handlebars-helpers/compare/v0.2.0...v0.2.1) (2018-10-15)
-
 
 ### Bug Fixes
 
 * **highlight:** fix to use hljs.highlight from hljs.highlightAuto ([5017f15](https://github.com/hidoo/handlebars-helpers/commit/5017f15))
 * **markdown:** fix to use hljs.highlight from hljs.highlightAuto ([b0e5033](https://github.com/hidoo/handlebars-helpers/commit/b0e5033))
 
-
-
 <a name="0.2.0"></a>
 # [0.2.0](https://github.com/hidoo/handlebars-helpers/compare/v0.1.1...v0.2.0) (2018-10-04)
-
 
 ### Features
 
 * **highlight:** add helper that apply syntax highlight ([d77a8d2](https://github.com/hidoo/handlebars-helpers/commit/d77a8d2))
 * **markdown:** change to output highlighted html when inputed value include code blocks ([4ac6635](https://github.com/hidoo/handlebars-helpers/commit/4ac6635))
 
-
-
 <a name="0.1.1"></a>
 ## [0.1.1](https://github.com/hidoo/handlebars-helpers/compare/v0.1.0...v0.1.1) (2018-08-22)
-
-
 
 <a name="0.1.0"></a>
 # 0.1.0 (2018-08-20)

--- a/packages/handlebars-helpers/package.json
+++ b/packages/handlebars-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hidoo/handlebars-helpers",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "description": "A helper library that summarizes commonly used functions in Handlebars.",
   "engines": {
     "node": ">=18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  glob-parent: ^6.0.0
-  minimist: ^1.2.5
-  trim-newlines: ^4.0.0
-
 importers:
 
   .:
@@ -53,7 +48,7 @@ importers:
         specifier: 10.3.10
         version: 10.3.10
       glob-parent:
-        specifier: ^6.0.0
+        specifier: 6.0.2
         version: 6.0.2
       handlebars:
         specifier: 4.7.8
@@ -475,7 +470,7 @@ packages:
       '@commitlint/types': 19.0.3
       execa: 8.0.1
       git-raw-commits: 4.0.0
-      minimist: 1.2.6
+      minimist: 1.2.8
     dev: true
 
   /@commitlint/resolve-extends@19.1.0:
@@ -1847,7 +1842,7 @@ packages:
     dependencies:
       anymatch: 3.1.3
       braces: 3.0.2
-      glob-parent: 6.0.2
+      glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
       normalize-path: 3.0.0
@@ -2993,7 +2988,7 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.4
       '@nodelib/fs.walk': 1.2.6
-      glob-parent: 6.0.2
+      glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
     dev: true
@@ -3282,6 +3277,13 @@ packages:
   /github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
     dev: false
+
+  /glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
 
   /glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -4321,6 +4323,10 @@ packages:
 
   /minimist@1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+
+  /minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: true
 
   /minipass-collect@2.0.1:
     resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}


### PR DESCRIPTION
### BREAKING CHANGES

* Requires ES Modules.
* Drop Node.js 12, 14, 16 support
