### PR TITLE
ci(node): add support for node.js v22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         node-version:
           - 18.x
           - 20.x
+          - 22.x
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Features
+ Add support for Node.js v22.

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖